### PR TITLE
Enable AnonymOS build options

### DIFF
--- a/compiler/src/build.d
+++ b/compiler/src/build.d
@@ -1680,7 +1680,7 @@ bool download(string to, string from, uint tries = 3)
 /**
 Detects the host OS.
 
-Returns: a string from `{windows, osx,linux,freebsd,openbsd,netbsd,dragonflybsd,solaris}`
+Returns: a string from `{windows, osx,linux,freebsd,openbsd,netbsd,dragonflybsd,solaris,anonymos}`
 */
 string detectOS()
 {
@@ -1700,6 +1700,8 @@ string detectOS()
         return "dragonflybsd";
     else version(Solaris)
         return "solaris";
+    else version(AnonymOS)
+        return "anonymos";
     else
         static assert(0, "Unrecognized or unsupported OS.");
 }

--- a/compiler/src/dmd/globals.d
+++ b/compiler/src/dmd/globals.d
@@ -300,13 +300,13 @@ extern (C++) struct Global
     const(char)[] inifilename; /// filename of configuration file as given by `-conf=`, or default value
 
     string copyright = "Copyright (C) 1999-2025 by The D Language Foundation, All Rights Reserved";
-    string written = "written by Walter Bright";
+    string written = "written by Walter Bright\nAnonymOS support by Jonathan R. Anderson";
 
     Array!(ImportPathInfo) path;       /// Array of path informations which form the import lookup path
     Array!(const(char)*) importPaths;  /// Array of char*'s which form the import lookup path without metadata
     Array!(const(char)*) filePath;     /// Array of char*'s which form the file import lookup path
 
-    private enum string _version = import("VERSION");
+    private enum string _version = import("VERSION") ~ "-AnonymOS";
     char[26] datetime;      /// string returned by ctime()
     CompileEnv compileEnv;
 


### PR DESCRIPTION
## Summary
- allow build.d to detect `anonymos`
- show AnonymOS support in `dmd --version`

## Testing
- `make -j2 dmd` *(fails: Couldn't find a D host compiler)*

------
https://chatgpt.com/codex/tasks/task_e_68880392d7ec8327a6c2955d0902fc55